### PR TITLE
Added MathJax support for math equations

### DIFF
--- a/js/markdownify.js
+++ b/js/markdownify.js
@@ -51,6 +51,11 @@
           smartypants: false,
         });
        */
+        // Hack to work around a marked.js bug.
+        data = data.replace(/\\\(/g, "\\\\(");
+        data = data.replace(/\\\)/g, "\\\\)");
+        data = data.replace(/\\\[/g, "\\\\[");
+        data = data.replace(/\\\]/g, "\\\\]");
         var html = marked(data);
         $(document.body).html(html);
         setCodeHighlight();
@@ -92,6 +97,16 @@
                 }
             });
         }
+    }
+
+    function setMathJax() {
+        var mjc = $('<script/>').attr('type', 'text/x-mathjax-config')
+        .html("MathJax.Hub.Config({tex2jax: {inlineMath: [ ['$','$'], ['\\\\(','\\\\)'] ],processEscapes:true}});");
+        $(document.head).append(mjc);
+        var js = $('<script/>').attr('type','text/javascript')
+        .attr('src','http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML');
+        $(document.head).append(js);
+
     }
 
     function setCodeHighlight() {
@@ -143,6 +158,12 @@
                         theme = items[pageKey];
                     }
                     setTheme(theme);
+                });
+
+                storage.get('mathjax', function(items) {
+                    if(items.mathjax) {
+                        setMathJax()
+                    }
                 });
 
                 storage.get('auto_reload', function(items) {

--- a/js/markdownify.js
+++ b/js/markdownify.js
@@ -51,14 +51,17 @@
           smartypants: false,
         });
        */
-        // Hack to work around a marked.js bug.
-        data = data.replace(/\\\(/g, "\\\\(");
-        data = data.replace(/\\\)/g, "\\\\)");
-        data = data.replace(/\\\[/g, "\\\\[");
-        data = data.replace(/\\\]/g, "\\\\]");
-        var html = marked(data);
-        $(document.body).html(html);
-        setCodeHighlight();
+        storage.get('mathjax', function(items) {
+            if(items.mathjax) {
+                data = data.replace(/\\\(/g, "\\\\(");
+                data = data.replace(/\\\)/g, "\\\\)");
+                data = data.replace(/\\\[/g, "\\\\[");
+                data = data.replace(/\\\]/g, "\\\\]");
+            }
+            var html = marked(data);
+            $(document.body).html(html);
+            setCodeHighlight();
+        });
     }
 
     function getThemeCss(theme) {

--- a/js/options.js
+++ b/js/options.js
@@ -14,6 +14,23 @@ function message(text, type) {
     }, 3000);
 }
 
+// mathjax
+storage.get('mathjax', function(items) {
+    if(items.mathjax) {
+        $('#mathjax').attr('checked', 'checked');
+    } else {
+        $('#mathjax').removeAttr('checked');
+    }
+});
+
+$('#mathjax').change(function() {
+    if($(this).prop('checked')) {
+        storage.set({'mathjax' :1});
+    } else {
+        storage.remove('mathjax');
+    }
+});
+
 // auto-reload
 storage.get('auto_reload', function(items) {
     if(items.auto_reload) {

--- a/options.html
+++ b/options.html
@@ -20,6 +20,9 @@
             <h2>Miscs</h2>
         </div>
         <p>
+        <label class="checkbox"><input type="checkbox" id="mathjax">Enable MathJax</label>
+        </p>
+        <p>
         <label class="checkbox"><input type="checkbox" id="auto-reload">Enable auto-reload</label>
         </p>
         <p>


### PR DESCRIPTION
Added support for the rendering of LaTeX style math equation notations through mathjax.
I intensively uses mathjax for LaTeX equations in my markdown documents, since this extension lacks these feature so I added it myself.

However, I noticed that while LaTeX often uses `\( \)` and `\[ \]` for recognizing math context, marked.js used in this extension would remove backslashes before the brackets. This should not be an intended behavior and should be fixed upstream, I would sooner submit an issue to them.

Currently, I'm using a [hack](https://github.com/chaserhkj/markdown-preview/commit/bb2e4272efcf2ab1c213751fa58bc669c71e90c1#diff-a2859c3ef05f6748e11600e77b951329R54) to workaround this issue by replacing single backslash before brackets to double backslashes.

Please consider merge this.
Happy Hacking!