### PR TITLE
Improved MathJax integration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,22 +10,63 @@ Features
 --------
 
 1. Support auto reload.
-1. Support external css file.
-1. Customize theme for every md file.
-1. Support github flavored markdown.
-1. Export nicely formatted HTML.
-1. Support MathJax.
+2. Support external css file.
+3. Customize theme for every md file.
+4. Support github flavored markdown.
+5. Export nicely formatted HTML.
+6. Support MathJax.
 
 Usage
---------
+-----
 
 1. Install extension from [webstore][] (creates no new UI)
 2. Check "Allow access to file URLs" in `chrome://extensions` listing: ![fileurls](http://i.imgur.com/qth3K.png)
 3. Open local or remote .md file in Chrome.
 4. See nicely formatted HTML!
 
+Supported Math Syntax
+---------------------
+
+To minimize conflict between Markdown and MathJax, MathJax has been configured
+to recognize the following math syntax.  Unfortunately, several standard LaTeX
+delimiters were explicitly disabled to avoid conflict with Markdown syntax
+(i.e., we prioritized Markdown over LaTeX).
+
+### Inline Math ###
+
+* __Double Backslash with Parentheses__:
+  <span class="tex2jax_ignore">`\\(math\\)`<span/>
+
+### Display Math ###
+
+* __Double Dollar Signs__:
+  <span class="tex2jax_ignore">`$$math$$`<span/>
+
+* __Double Backslash with Brackets__:
+  <span class="tex2jax_ignore">`\\[math\\]`<span/>
+
+* __LaTeX Environments__:
+  <span class="tex2jax_ignore">`\begin{equation}math\end{equation}`<span/>
+
+### Unsupported Math Syntax ###
+
+* __Single Dollar Signs__:
+  <span class="tex2jax_ignore">`$math$`<span/>.
+  This syntax (from LaTeX) is not supported because it conflicts with the use
+  of the dollar sign in financial contexts.
+
+* __Single Backslash with Parentheses__:
+  <span class="tex2jax_ignore">`\(math\)`<span/>.
+  This syntax (from LaTeX) is not supported because it conflicts with
+  Markdown's escaped syntax for parentheses `\(`.
+
+* __Single Backslash with Brackets__:
+  <span class="tex2jax_ignore">`\[math\]`<span/>.
+  This syntax (from LaTeX) is not supported because it conflicts with
+  Markdown's escaped syntax for brackets `\[`.
+
 Thanks
--------
+------
 
 Thanks to Kevin Burke for his [markdown-friendly stylesheet][style],
 to chjj for his [JavaScript markdown processor][marked],

--- a/js/markdownify.js
+++ b/js/markdownify.js
@@ -121,7 +121,7 @@
 
     function setMathJax() {
         var mjc = $('<script/>').attr('type', 'text/x-mathjax-config')
-            .html("MathJax.Hub.Config({tex2jax: {inlineMath: [ ['\\\\\\\\(', '\\\\\\\\)'] ], displayMath: [ ['\\\\\\\\[', '\\\\\\\\]'] ], processEscapes:false}});");
+            .html("MathJax.Hub.Config({tex2jax: {inlineMath: [ ['\\\\\\\\(', '\\\\\\\\)'] ], displayMath: [ ['$$', '$$'], ['\\\\\\\\[', '\\\\\\\\]'] ], processEscapes:false}});");
         $(document.head).append(mjc);
         var js = $('<script/>').attr('type','text/javascript')
             .attr('src', 'https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML');

--- a/js/runMathJax.js
+++ b/js/runMathJax.js
@@ -1,3 +1,28 @@
-if ((typeof window.MathJax != 'undefined') && (typeof window.MathJax.Hub != 'undefined')) {
-    window.MathJax.Hub.Queue(["Typeset", window.MathJax.Hub]);
-}
+(function(document) {
+    if ((typeof window.MathJax != 'undefined') && (typeof window.MathJax.Hub != 'undefined')) {
+
+        // Apply MathJax typesetting
+        var mathjaxDiv = document.getElementById("mathjaxProcessing");
+
+        // Apply Markdown parser after MathJax typesetting is complete
+        window.MathJax.Hub.Queue(["Typeset", window.MathJax.Hub,
+                                  mathjaxDiv]);
+
+        window.MathJax.Hub.Register.StartupHook("End Typeset",
+            function () {
+                marked.setOptions({
+                    highlight : function(code) {
+                        return hljs.highlightAuto(code).value;
+                    }
+                });
+
+                // Convert Markdown to HTML and replace document body
+                var html = marked(mathjaxDiv.innerHTML);
+                document.body.innerHTML = html;
+
+                // Remove div used for MathJax processing
+                mathjaxDiv.remove();
+            }
+        );
+    }
+}(document));

--- a/manifest.json
+++ b/manifest.json
@@ -41,8 +41,8 @@
     }
   ],
   "permissions": [
-      "storage", 
-      "tabs", 
+      "storage",
+      "tabs",
       "pageCapture",
       "downloads",
       "<all_urls>"
@@ -58,8 +58,9 @@
       "theme/i/doc.png",
       "theme/i/email.png",
       "theme/i/folder.png",
-      "js/popup.js", 
-      "js/runMathJax.js", 
+      "js/popup.js",
+      "js/runMathJax.js",
+      "js/marked.js",
       "js/options.js"
   ],
   "browser_action" : {


### PR DESCRIPTION
I noticed that mathematical expressions involving multiple subscripts often got corrupted when they were rendered using Markdown Preview Plus.  I traced the origin of the problem to the order that the Markdown parser and MathJax processing are applied to the input file.  I have modified the codebase to apply MathJax first and then Markdown.  While, in principle, this could lead to corruption of Markdown rendering, I believe it would be less common for a mathematical formula to accidentally match Markdown syntax than for Markdown syntax to match LaTeX formula (e.g., MathJax would render "A_i + B_i = C_i" incorrectly because Markdown would interpret the characters between the underscores as needing emphasis).

In addition, I have made the following other contributions to the codebase:

* Improved supported MathJax syntax to avoid conflicts with Markdown while still being reasonably intuitive to LaTeX users.

* Added a section to the README file about supported and unsupported math syntax.

* Fixed a small bug in the MathJax configuration to eliminate the need to use search-and-replace to fix the input data before MathJax and Markdown processing.