### PR TITLE
Consolidated configuration parameters in config.js

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -1,0 +1,46 @@
+var config = (function() {
+    // Define module
+    var module = {};
+
+    // Private module properties
+    var latexDelimitersEnabled = false;
+
+    // Public module properties
+    module.markedOptions = {
+        gfm : true,
+        tables: true,
+        breaks: false,
+        highlight : function(code) {
+            return hljs.highlightAuto(code).value;
+        }
+    };
+
+    module.mathjaxProcessingElementId = "mathjaxProcessing";
+
+    // Note: when math delimiters are set in JS as strings, backslashes need
+    // to be escaped
+    module.mathjaxConfig = {
+        tex2jax: {
+            inlineMath: [ ['\\\\(', '\\\\)'] ],
+            displayMath: [ ['$$', '$$'], ['\\\\[', '\\\\]'] ],
+            processEscapes: false
+        }
+    };
+
+    // Public module functions
+    module.enableLatexDelimiters = function() {
+        if (!latexDelimitersEnabled) {
+            // Note: when math delimiters are set in JS as strings,
+            // backslashes need to be escaped
+            module.mathjaxConfig.tex2jax.inlineMath.push(['$', '$']);
+            module.mathjaxConfig.tex2jax.inlineMath.push(['$', '$']);
+            module.mathjaxConfig.tex2jax.inlineMath.push(['\\(', '\\)']);
+            module.mathjaxConfig.tex2jax.displayMath.push(['\\[', '\\]']);
+            module.mathjaxConfig.tex2jax.processEscapes = true;
+
+            latexDelimitersEnabled = true;
+        }
+    }
+
+    return module;
+}());

--- a/js/config.js
+++ b/js/config.js
@@ -1,4 +1,4 @@
-var config = (function() {
+var config = (function(hljs) {
     // Define module
     var module = {};
 
@@ -43,4 +43,4 @@ var config = (function() {
     }
 
     return module;
-}());
+}(hljs));

--- a/js/runMathJax.js
+++ b/js/runMathJax.js
@@ -2,7 +2,8 @@
     if ((typeof window.MathJax != 'undefined') && (typeof window.MathJax.Hub != 'undefined')) {
 
         // Apply MathJax typesetting
-        var mathjaxDiv = document.getElementById("mathjaxProcessing");
+        var mathjaxDiv =
+            document.getElementById(config.mathjaxProcessingElementId);
 
         // Apply Markdown parser after MathJax typesetting is complete
         window.MathJax.Hub.Queue(["Typeset", window.MathJax.Hub,
@@ -10,14 +11,7 @@
 
         window.MathJax.Hub.Register.StartupHook("End Typeset",
             function () {
-                marked.setOptions({
-                    gfm : true,
-                    tables: true,
-                    breaks: true,
-                    highlight : function(code) {
-                        return hljs.highlightAuto(code).value;
-                    }
-                });
+                marked.setOptions(config.markedOptions);
 
                 // Convert Markdown to HTML and replace document body
                 var html = marked(mathjaxDiv.innerHTML);

--- a/manifest.json
+++ b/manifest.json
@@ -34,6 +34,7 @@
           "js/jquery.js",
           "js/marked.js",
           "js/highlight.js",
+          "js/config.js",
           "js/markdownify.js"
       ]
     }
@@ -58,6 +59,7 @@
       "theme/i/folder.png",
       "js/highlight.js",
       "js/popup.js",
+      "js/config.js",
       "js/runMathJax.js",
       "js/marked.js",
       "js/options.js"


### PR DESCRIPTION
After the last update to marked options, I realized that the options were used in two places (markdownify.js and runMathJax.js) and had gotten out of sync.  To avoid different behavior when MathJax is enabled vs disabled and simplify code maintenance, I created a config.js module to consolidate common configuration parameters (e.g. marked options, MathJax configuration).