### PR TITLE
Fix bug when MathJax is enabled and Markdown contains invalid HTML tags.

### DIFF
--- a/js/markdownify.js
+++ b/js/markdownify.js
@@ -46,7 +46,7 @@
                 var mathjaxDiv = document.createElement("div");
                 mathjaxDiv.setAttribute("id",
                                         config.mathjaxProcessingElementId);
-                mathjaxDiv.innerHTML = data;
+                $(mathjaxDiv).text(data);
                 mathjaxDiv.style.display = 'none';
                 document.body.appendChild(mathjaxDiv);
             }

--- a/js/runMathJax.js
+++ b/js/runMathJax.js
@@ -13,8 +13,13 @@
             function () {
                 marked.setOptions(config.markedOptions);
 
+                // Decode &lt; and &gt;
+                mathjaxData = mathjaxDiv.innerHTML;
+                mathjaxData = mathjaxData.replace(/&lt;/g, "<");
+                mathjaxData = mathjaxData.replace(/&gt;/g, ">");
+
                 // Convert Markdown to HTML and replace document body
-                var html = marked(mathjaxDiv.innerHTML);
+                var html = marked(mathjaxData);
                 document.body.innerHTML = html;
 
                 // Remove div used for MathJax processing


### PR DESCRIPTION
When MathJax is enabled and the Markdown contains invalid HTML tags (e.g. <email@example.com>), the rendered HTML contains extra junk at the end of the body.  To fix this problem, I circumvented the HTML parser when saving the original Markdown data file to the mathjaxDiv and manually fixing the encoded '<' and '>' characters.