### PR TITLE
Made GFM task list read-only

### DIFF
--- a/js/marked.js
+++ b/js/marked.js
@@ -835,7 +835,7 @@ Renderer.prototype.listitem = function(text, checked) {
   }
 
   return '<li class="task-list-item">'
-    + '<input type="checkbox" class="task-list-item-checkbox"'
+    + '<input type="checkbox" class="task-list-item-checkbox" disabled="disabled"'
     + (checked ? ' checked' : '')
     + '> '
     + text


### PR DESCRIPTION
Closes #77

Based on the discussion at:
https://stackoverflow.com/questions/155291/can-html-checkboxes-be-set-to-readonly

And the Github's rendering of task list:

```
- [x] TODO 1
- [ ] TODO 2
```
as:
- [x] TODO 1
- [ ] TODO 2

I feel that the solution closest to GFM is to use ```disabled="disabled"``` approach.
