### PR TITLE
Hid bullet symbols for GFM task list items.

### DIFF
--- a/js/marked.js
+++ b/js/marked.js
@@ -834,7 +834,7 @@ Renderer.prototype.listitem = function(text, checked) {
     return '<li>' + text + '</li>\n';
   }
 
-  return '<li class="task-list-item">'
+  return '<li class="task-list-item" style="list-style-type:none;">'
     + '<input type="checkbox" class="task-list-item-checkbox" disabled="disabled"'
     + (checked ? ' checked' : '')
     + '> '


### PR DESCRIPTION
Used inline style to ensure that themes would not need to explicitly take care of hiding bullet symbols for task list items.

Closes #79.