### PR TITLE
Support for math syntax used in GitLab markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ with Markdown syntax.  LaTeX syntax can be enabled in the options.
 * __Double Backslash with Parentheses__:
   <code class="tex2jax_ignore">`\\(math\\)`</code>
 
+* __Single Dollar with Backquote__:
+  <code class="tex2jax_ignore">``$`math`$``</code>
+
 ### Display Math ###
 
 * __Single Backslash with Brackets__ (requires LaTeX delimiters):
@@ -58,6 +61,13 @@ with Markdown syntax.  LaTeX syntax can be enabled in the options.
 
 * __Double Dollar Signs__:
   <code class="tex2jax_ignore">`$$math$$`</code>
+
+* __Math Code Block__:
+  ````
+  ```math
+  math
+  ```
+  ````
 
 Thanks
 ------

--- a/js/diagramflowseq.js
+++ b/js/diagramflowseq.js
@@ -98,12 +98,7 @@ function drawAllFlow() {
     }
 }
 
-function replaceMathString(src) {
-    var out = src;
-    var pattern = /(\${1,2})((?:\\.|[\s\S])+?)\1|(\\\[)((?:\\.|[\s\S])+?)(\\])|(\\\()((?:\\.|[\s\S])+?)(\\\))/g;
-    var mc = null;
-    var codeBegin = src.search('<code>');
-    var codeEnd = src.search('</code>');
+function renderKatex(srcMath, isDisplay) {
     var unEscape = function(html) {
         return html
                 .replace(/&amp;/g, '&')
@@ -113,6 +108,25 @@ function replaceMathString(src) {
                 .replace(/&#39;/g, '\'')
                 .replace(/\\$/g, '');
     }
+    var repMath = "";
+    srcMath = unEscape(srcMath);
+    try {
+        repMath = katex.renderToString(srcMath, {displayMode: isDisplay});
+        repMath = repMath.replace(/\n/g, '');
+    }
+    catch(err) {
+        console.error("katex parse math string[" + srcMath + "] failed! throw error: " + err);
+        repMath = "";
+    }
+    return repMath;
+}
+
+function replaceMathString(src) {
+    var out = src;
+    var pattern = /(\$`)((?:\\.|[\s\S])+?)(`\$)|(\${1,2})((?:\\.|[\s\S])+?)\4|(\\\[)((?:\\.|[\s\S])+?)(\\])|(\\\()((?:\\.|[\s\S])+?)(\\\))/g;
+    var mc = null;
+    var codeBegin = src.search('<code>');
+    var codeEnd = src.search('</code>');
     while (null != (mc = pattern.exec(src))) {
         //I don't know how to build the regular expression to exclude the Code tag.
         if(codeBegin > -1 && codeEnd > -1 && mc.index > codeBegin && mc.index < codeEnd) {
@@ -121,34 +135,29 @@ function replaceMathString(src) {
         else {
             var srcMath = "";
             var isDisplay = false;
-            if (mc[1]) { //match $ or $$
+            if (mc[1]) { //match $` `$
+                isDisplay = false;
                 srcMath = mc[2];
-                if(mc[1] === '$$') {
+            }
+            else if (mc[4]) { //match $ or $$
+                srcMath = mc[5];
+                if(mc[4] === '$$') {
                     isDisplay = true;
                 }
                 else {
                     isDisplay = false;
                 }
             }
-            else if (mc[3]) { //match \\[ \\]
+            else if (mc[6]) { //match \\[ \\]
                 isDisplay = true;
-                srcMath = mc[4];
-            }
-            else if (mc[6]) { //match \\( \\)
-                isDisplay = false;
                 srcMath = mc[7];
             }
+            else if (mc[9]) { //match \\( \\)
+                isDisplay = false;
+                srcMath = mc[10];
+            }
 
-            var repMath = "";
-            srcMath = unEscape(srcMath);
-            try {
-                repMath = katex.renderToString(srcMath, {displayMode: isDisplay});
-                repMath = repMath.replace(/\n/g, '');
-            }
-            catch(err) {
-                console.error("kate parse math string[" + srcMath + "] failed! throw error: " + err);
-                repMath = "";
-            }
+            var repMath = renderKatex(srcMath, isDisplay);
             if (repMath && repMath.length != 0) {
                 out = out.replace(mc[0], repMath);
             }
@@ -175,6 +184,9 @@ function prepareSpecialCode(lang, code) {
         else {
             retStr = '<code>' + code + '</code>\n';
         }
+    }
+    else if (lang === "math") {
+        retStr = renderKatex(code, true);
     }
     return retStr;
 }
@@ -204,7 +216,7 @@ function prepareDiagram(data) {
     var lines = data.split('\n');
     var retStr = "";
     var curStatus = "";
-    var preLangs = ["flow", "sequence", "puml"];
+    var preLangs = ["flow", "sequence", "puml", "math"];
     var lang = "";
     var tmpCode = "";
     var isInCode = function () { 

--- a/test/test_katex.markdown
+++ b/test/test_katex.markdown
@@ -1,7 +1,7 @@
 use KaTex formula test
 -------------------
 
-* inline data $Z_{0..n}$ and formula $\frac{1}{x}$ mix test
+* inline data $`Z_{0..n}`$ and formula $\frac{1}{x}$ mix test
 
 * mix inline formula $Z_{0..n}$ outline formula \\[ A_i = B_i + C_{i} \sum_{k=0}^{i} D_k E^k + dx \\]
 and few formual in Paragraph test
@@ -24,6 +24,9 @@ $$ \Gamma(x) = \int_{0}^{+\infty} t^{x-1}e^{-t}dt $$
 * Single backslash with brackets.
   \[  A_i = B_i + C_i \sum_{k=0}^{i} D_k E^k + dx \]
 
+* Single dollar and backquote
+  $`  A_i = B_i + C_i \sum_{k=0}^{i} D_k E^k + dx + dy `$
+
 
 * Test multi-row formula
 $$
@@ -43,6 +46,16 @@ $$
   \end{matrix}
   \right\} \tag{2}
 \]
+
+```math
+ \left[
+ \begin{matrix}
+   1 & 2 & 3 \\
+   4 & 5 & 6 \\
+   7 & 8 & 9
+  \end{matrix}
+  \right] \tag{3}
+```
 
 * test formula in php code 
 


### PR DESCRIPTION
Issue #107
- Inline math with a dollar and a backquote (`` $` `` ... `` `$ ``)
- Math code block (```math)